### PR TITLE
Matching v4 (wip)

### DIFF
--- a/src/parser/expression.js
+++ b/src/parser/expression.js
@@ -832,7 +832,7 @@ pp.parseExprAtom = function (refShorthandDefaultPos) {
       if (this.state.inMatchAtom && this.hasPlugin("lightscript")) {
         // Predicate
         node = this.startNodeAt(this.state.lastTokEnd, this.state.lastTokEndLoc);
-        return this.finishNodeAt(node, "PlaceholderExpression", this.state.start, this.state.startLoc);
+        return this.finishNodeAt(node, "MatchPlaceholderExpression", this.state.start, this.state.startLoc);
       }
 
     default:

--- a/src/parser/expression.js
+++ b/src/parser/expression.js
@@ -275,6 +275,9 @@ pp.parseExprOp = function(left, leftStartPos, leftStartLoc, minPrec, noIn) {
       }
 
       const op = this.state.type;
+      if ( this.state.inMatchAtom && (op !== tt.logicalOR && op !== tt.logicalAND)) {
+        this.unexpected(null, "Illegal operator in match atom.");
+      }
       this.next();
 
       const startPos = this.state.start;
@@ -303,6 +306,10 @@ pp.parseMaybeUnary = function (refShorthandDefaultPos) {
     // `not` -> `!` etc.
     if (this.hasPlugin("lightscript")) this.rewriteOperator(node);
 
+    if (this.state.inMatchAtom && node.operator !== "!") {
+      this.unexpected(null, "Illegal operator in match atom");
+    }
+
     node.prefix = true;
     this.next();
 
@@ -328,6 +335,11 @@ pp.parseMaybeUnary = function (refShorthandDefaultPos) {
   const startLoc = this.state.startLoc;
   let expr = this.parseExprSubscripts(refShorthandDefaultPos);
   if (refShorthandDefaultPos && refShorthandDefaultPos.start) return expr;
+
+  if (this.state.inMatchAtom && this.state.type.postfix) {
+    this.unexpected(null, "Illegal operator in match atom.");
+  }
+
   while (this.state.type.postfix && !this.canInsertSemicolon()) {
     const node = this.startNodeAt(startPos, startLoc);
     node.operator = this.state.value;
@@ -620,6 +632,9 @@ pp.parseExprAtom = function (refShorthandDefaultPos) {
 
     case tt._import:
       if (!this.hasPlugin("dynamicImport")) this.unexpected();
+      if (this.state.inMatchAtom) {
+        this.unexpected(null, "Illegal expression in match atom.");
+      }
 
       node = this.startNode();
       this.next();
@@ -634,6 +649,9 @@ pp.parseExprAtom = function (refShorthandDefaultPos) {
       return this.finishNode(node, "ThisExpression");
 
     case tt._yield:
+      if (this.state.inMatchAtom) {
+        this.unexpected(null, "Illegal expression in match atom.");
+      }
       if (this.state.inGenerator) this.unexpected();
 
     case tt.name:
@@ -664,6 +682,9 @@ pp.parseExprAtom = function (refShorthandDefaultPos) {
 
     case tt._do:
       if (this.hasPlugin("doExpressions")) {
+        if (this.state.inMatchAtom) {
+          this.unexpected(null, "Illegal expression in match atom.");
+        }
         const node = this.startNode();
         this.next();
         const oldInFunction = this.state.inFunction;
@@ -704,6 +725,9 @@ pp.parseExprAtom = function (refShorthandDefaultPos) {
       return this.parseParenAndDistinguishExpression(null, null, canBeArrow);
 
     case tt.bracketL:
+      if (this.state.inMatchAtom) {
+        this.unexpected(null, "Illegal expression in match atom.");
+      }
       node = this.startNode();
       this.next();
       if (this.hasPlugin("lightscript") && this.match(tt._for)) {
@@ -714,20 +738,35 @@ pp.parseExprAtom = function (refShorthandDefaultPos) {
       return this.finishNode(node, "ArrayExpression");
 
     case tt.braceL:
+      if (this.state.inMatchAtom) {
+        this.unexpected(null, "Illegal expression in match atom.");
+      }
       return this.parseObj(false, refShorthandDefaultPos);
 
     case tt._function:
+      if (this.state.inMatchAtom) {
+        this.unexpected(null, "Illegal expression in match atom.");
+      }
       return this.parseFunctionExpression();
 
     case tt.at:
+      if (this.state.inMatchAtom) {
+        this.unexpected(null, "Illegal expression in match atom.");
+      }
       this.parseDecorators();
 
     case tt._class:
+      if (this.state.inMatchAtom) {
+        this.unexpected(null, "Illegal expression in match atom.");
+      }
       node = this.startNode();
       this.takeDecorators(node);
       return this.parseClass(node, false);
 
     case tt._new:
+      if (this.state.inMatchAtom) {
+        this.unexpected(null, "Illegal expression in match atom.");
+      }
       return this.parseNew();
 
     case tt.backQuote:
@@ -746,6 +785,9 @@ pp.parseExprAtom = function (refShorthandDefaultPos) {
 
     case tt._if:
       if (this.hasPlugin("lightscript")) {
+        if (this.state.inMatchAtom) {
+          this.unexpected(null, "Illegal expression in match atom.");
+        }
         node = this.startNode();
         return this.parseIfExpression(node);
       }
@@ -758,12 +800,18 @@ pp.parseExprAtom = function (refShorthandDefaultPos) {
 
     case tt.arrow:
       if (this.hasPlugin("lightscript")) {
+        if (this.state.inMatchAtom) {
+          this.unexpected(null, "Illegal expression in match atom.");
+        }
         node = this.startNode();
         return this.parseArrowExpression(node, []);
       }
 
     case tt.awaitArrow:
       if (this.hasPlugin("lightscript")) {
+        if (this.state.inMatchAtom) {
+          this.unexpected(null, "Illegal expression in match atom.");
+        }
         node = this.startNode();
         const isSafe = this.state.value === "<!-";
         this.next();
@@ -778,6 +826,13 @@ pp.parseExprAtom = function (refShorthandDefaultPos) {
     case tt.dot:
       if (this.hasPlugin("lightscript") && this.lookahead().type === tt.num) {
         this.unexpected(null, "Decimal numbers must be prefixed with a `0` in LightScript (eg; `0.1`).");
+      }
+
+    case tt.tilde:
+      if (this.state.inMatchAtom && this.hasPlugin("lightscript")) {
+        // Predicate
+        node = this.startNodeAt(this.state.lastTokEnd, this.state.lastTokEndLoc);
+        return this.finishNodeAt(node, "PlaceholderExpression", this.state.start, this.state.startLoc);
       }
 
     default:

--- a/src/plugins/match.js
+++ b/src/plugins/match.js
@@ -134,3 +134,160 @@ export function match_v3(parser) {
   };
 
 }
+
+// v4 of the match syntax
+// MatchStatement = match x:\n\t| MatchCase[\n\t| MatchCase ...]
+// MatchCase = | [if Expr:] [MatchAtom, MatchAtom, ...] [with|as MatchBinding] [if Expr]: Block
+// MatchElse = | else [as MatchBinding]: Block
+// MatchBinding = ArrayPattern|ObjectPattern
+// MatchAtom = ExprOps
+export function match_v4(parser) {
+  if (parser.__matchPluginInstalled) {
+    throw new Error("cannot install multiple `match` plugins");
+  }
+  parser.__matchPluginInstalled = true;
+
+  pp.parseMatchExpression = function (node) {
+    return this.parseMatch(node, true);
+  };
+
+  pp.parseMatchStatement = function (node) {
+    return this.parseMatch(node, false);
+  };
+
+  pp.parseMatch = function (node, isExpression) {
+    if (this.state.inMatchCaseTest) this.unexpected(null, "`match` is illegal in a match case test");
+    this.expect(tt._match);
+
+    node.discriminant = this.parseParenExpression();
+
+    const isColon = this.match(tt.colon);
+    let isEnd;
+    if (isColon) {
+      const indentLevel = this.state.indentLevel;
+      this.next();
+      isEnd = () => this.state.indentLevel <= indentLevel || this.match(tt.eof);
+    } else {
+      this.expect(tt.braceL);
+      isEnd = () => this.eat(tt.braceR);
+    }
+
+    node.cases = [];
+    const caseIndentLevel = this.state.indentLevel;
+    let hasUsedElse = false;
+    while (!isEnd()) {
+      if (hasUsedElse) {
+        this.unexpected(null, "`else` must be last case.");
+      }
+      if (isColon && this.state.indentLevel !== caseIndentLevel) {
+        this.unexpected(null, "Mismatched indent.");
+      }
+
+      const matchCase = this.parseMatchCase(isExpression);
+      if (matchCase.test && matchCase.test.type === "MatchElse") {
+        hasUsedElse = true;
+      }
+      node.cases.push(matchCase);
+    }
+
+    if (!node.cases.length) {
+      this.unexpected(null, tt.bitwiseOR);
+    }
+
+    return this.finishNode(node, isExpression ? "MatchExpression" : "MatchStatement");
+  };
+
+  pp.parseMatchCase = function (isExpression) {
+    const node = this.startNode();
+
+    this.expect(tt.bitwiseOR);
+    if (this.isLineBreak()) this.unexpected(this.state.lastTokEnd, "Illegal newline.");
+
+    this.parseMatchCaseTest(node);
+    this.parseMatchCaseConsequent(node, isExpression);
+
+    return this.finishNode(node, "MatchCase");
+  };
+
+  pp.parseMatchCaseConsequent = function(node, isExpression) {
+    if (isExpression) {
+      // disallow return/continue/break, etc. c/p doExpression
+      const oldInFunction = this.state.inFunction;
+      const oldLabels = this.state.labels;
+      this.state.labels = [];
+      this.state.inFunction = false;
+
+      node.consequent = this.parseBlock(false);
+
+      this.state.inFunction = oldInFunction;
+      this.state.labels = oldLabels;
+    } else {
+      node.consequent = this.parseBlock(false);
+    }
+  };
+
+  pp.parseMatchCaseTest = function (node) {
+    // can't be nested so no need to read/restore old value
+    this.state.inMatchCaseTest = true;
+
+    if (this.match(tt._else)) {
+      const elseNode = this.startNode();
+      this.next();
+      node.outerGuard = this.finishNode(elseNode, "MatchElse");
+      this.parseMatchCaseBinding(node, true);
+    } else {
+      this.parseMatchCaseOuterGuard(node);
+      this.parseMatchCaseAtoms(node);
+      this.parseMatchCaseBinding(node);
+      this.parseMatchCaseInnerGuard(node);
+    }
+
+    this.state.inMatchCaseTest = false;
+  };
+
+  pp.parseMatchCaseBinding = function (node, isElse) {
+    if (node.binding) this.unexpected(this.state.lastTokStart, "Cannot destructure twice.");
+    if (this.eatContextual("as")) {
+      node.binding = this.parseMatchBindingAtom();
+      node.assertive = false;
+    } else if (!isElse && this.eat(tt._with)) {
+      node.binding = this.parseMatchBindingAtom();
+      node.assertive = true;
+    }
+  };
+
+  pp.parseMatchBindingAtom = function() {
+    if (!(this.match(tt.braceL) || this.match(tt.bracketL))) {
+      this.unexpected(null, "Expected an array or object destructuring pattern.");
+    }
+    return this.parseBindingAtom();
+  };
+
+  pp.parseMatchCaseOuterGuard = function(node) {
+    if (!this.eat(tt._if)) return;
+    node.outerGuard = this.parseParenExpression();
+  };
+
+  pp.parseMatchCaseInnerGuard = function(node) {
+    if (!this.eat(tt._if)) return;
+    node.innerGuard = this.parseParenExpression();
+  };
+
+  pp.parseMatchCaseAtoms = function(node) {
+    if (this.match(tt._if) || this.match(tt._with) || this.isContextual("as")) return;
+
+    const atoms = [];
+    while (true) {
+      atoms.push(this.parseMatchCaseAtom());
+      if (!this.eat(tt.comma)) break;
+    }
+
+    node.atoms = atoms;
+  };
+
+  pp.parseMatchCaseAtom = function() {
+    this.state.inMatchAtom = true;
+    return this.parseExprOps();
+    this.state.inMatchAtom = false;
+  };
+}

--- a/src/plugins/match.js
+++ b/src/plugins/match.js
@@ -136,11 +136,13 @@ export function match_v3(parser) {
 }
 
 // v4 of the match syntax
-// MatchStatement = match x:\n\t| MatchCase[\n\t| MatchCase ...]
-// MatchCase = | [if Expr:] [MatchAtom, MatchAtom, ...] [with|as MatchBinding] [if Expr]: Block
-// MatchElse = | else [as MatchBinding]: Block
+// MatchStatement = `match` Expr `:` `\n`MatchCase [`\n`MatchCase]...
+// MatchCase = `|` ` ` MatchTest | MatchElse
+// MatchTest = [`if` Expr:] [MatchAtom, MatchAtom, ...] [`with`|`as` MatchBinding] [`if` Expr]: Block
+// MatchElse = | `else` [`as` MatchBinding]: Block
 // MatchBinding = ArrayPattern|ObjectPattern
 // MatchAtom = ExprOps
+// (Most non-logical operations and strange expr types are illegal in MatchAtoms)
 export function match_v4(parser) {
   if (parser.__matchPluginInstalled) {
     throw new Error("cannot install multiple `match` plugins");
@@ -266,6 +268,7 @@ export function match_v4(parser) {
   pp.parseMatchCaseOuterGuard = function(node) {
     if (!this.eat(tt._if)) return;
     node.outerGuard = this.parseParenExpression();
+    this.eat(tt.colon);
   };
 
   pp.parseMatchCaseInnerGuard = function(node) {

--- a/src/plugins/match.js
+++ b/src/plugins/match.js
@@ -280,17 +280,13 @@ export function match_v4(parser) {
     if (this.match(tt._if) || this.match(tt._with) || this.isContextual("as")) return;
 
     const atoms = [];
+    this.state.inMatchAtom = true;
     while (true) {
-      atoms.push(this.parseMatchCaseAtom());
+      atoms.push(this.parseExprOps());
       if (!this.eat(tt.comma)) break;
     }
+    this.state.inMatchAtom = false;
 
     node.atoms = atoms;
-  };
-
-  pp.parseMatchCaseAtom = function() {
-    this.state.inMatchAtom = true;
-    return this.parseExprOps();
-    this.state.inMatchAtom = false;
   };
 }

--- a/src/registerPlugins.js
+++ b/src/registerPlugins.js
@@ -6,7 +6,7 @@ import safeCallExistentialPlugin from "./plugins/safeCallExistential";
 import bangCallPlugin from "./plugins/bangCall";
 import significantWhitespacePlugin from "./plugins/significantWhitespace";
 
-import { matchCoreSyntax, match_v3 } from "./plugins/match";
+import { matchCoreSyntax, match_v3, match_v4 } from "./plugins/match";
 
 function noncePlugin() {}
 
@@ -58,5 +58,11 @@ export default function registerPlugins(plugins, metadata) {
     // XXX: dependency on lsc for bitwise operators/ambiguities -- should be
     // possible to factor that out and completely separate match
     dependencies: ["lightscript", "matchCoreSyntax"]
+  });
+  registerPlugin("match_v4", match_v4, {
+    // XXX: dependency on lsc for bitwise operators/ambiguities -- should be
+    // possible to factor that out and completely separate match
+    dependencies: ["lightscript", "matchCoreSyntax"],
+    private: true
   });
 }

--- a/test/fixtures/match/v4/atom-as/actual.js
+++ b/test/fixtures/match/v4/atom-as/actual.js
@@ -1,0 +1,2 @@
+match x:
+  | Atom as {y}: y

--- a/test/fixtures/match/v4/atom-as/expected.json
+++ b/test/fixtures/match/v4/atom-as/expected.json
@@ -1,0 +1,207 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 27,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 2,
+      "column": 18
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 27,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 2,
+        "column": 18
+      }
+    },
+    "sourceType": "script",
+    "body": [
+      {
+        "type": "MatchStatement",
+        "start": 0,
+        "end": 27,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 2,
+            "column": 18
+          }
+        },
+        "discriminant": {
+          "type": "Identifier",
+          "start": 6,
+          "end": 7,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 6
+            },
+            "end": {
+              "line": 1,
+              "column": 7
+            },
+            "identifierName": "x"
+          },
+          "name": "x"
+        },
+        "cases": [
+          {
+            "type": "MatchCase",
+            "start": 11,
+            "end": 27,
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 2
+              },
+              "end": {
+                "line": 2,
+                "column": 18
+              }
+            },
+            "atoms": [
+              {
+                "type": "Identifier",
+                "start": 13,
+                "end": 17,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 4
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 8
+                  },
+                  "identifierName": "Atom"
+                },
+                "name": "Atom"
+              }
+            ],
+            "binding": {
+              "type": "ObjectPattern",
+              "start": 21,
+              "end": 24,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 12
+                },
+                "end": {
+                  "line": 2,
+                  "column": 15
+                }
+              },
+              "properties": [
+                {
+                  "type": "ObjectProperty",
+                  "start": 22,
+                  "end": 23,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 13
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 14
+                    }
+                  },
+                  "method": false,
+                  "shorthand": true,
+                  "computed": false,
+                  "key": {
+                    "type": "Identifier",
+                    "start": 22,
+                    "end": 23,
+                    "loc": {
+                      "start": {
+                        "line": 2,
+                        "column": 13
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 14
+                      },
+                      "identifierName": "y"
+                    },
+                    "name": "y"
+                  },
+                  "value": {
+                    "type": "Identifier",
+                    "start": 22,
+                    "end": 23,
+                    "loc": {
+                      "start": {
+                        "line": 2,
+                        "column": 13
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 14
+                      },
+                      "identifierName": "y"
+                    },
+                    "name": "y"
+                  },
+                  "extra": {
+                    "shorthand": true
+                  }
+                }
+              ]
+            },
+            "assertive": false,
+            "consequent": {
+              "type": "ExpressionStatement",
+              "start": 26,
+              "end": 27,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 17
+                },
+                "end": {
+                  "line": 2,
+                  "column": 18
+                }
+              },
+              "expression": {
+                "type": "Identifier",
+                "start": 26,
+                "end": 27,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 17
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 18
+                  },
+                  "identifierName": "y"
+                },
+                "name": "y"
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "directives": []
+  }
+}

--- a/test/fixtures/match/v4/atom-with/actual.js
+++ b/test/fixtures/match/v4/atom-with/actual.js
@@ -1,0 +1,2 @@
+match x:
+  | Atom with {y}: y

--- a/test/fixtures/match/v4/atom-with/expected.json
+++ b/test/fixtures/match/v4/atom-with/expected.json
@@ -1,0 +1,207 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 29,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 2,
+      "column": 20
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 29,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 2,
+        "column": 20
+      }
+    },
+    "sourceType": "script",
+    "body": [
+      {
+        "type": "MatchStatement",
+        "start": 0,
+        "end": 29,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 2,
+            "column": 20
+          }
+        },
+        "discriminant": {
+          "type": "Identifier",
+          "start": 6,
+          "end": 7,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 6
+            },
+            "end": {
+              "line": 1,
+              "column": 7
+            },
+            "identifierName": "x"
+          },
+          "name": "x"
+        },
+        "cases": [
+          {
+            "type": "MatchCase",
+            "start": 11,
+            "end": 29,
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 2
+              },
+              "end": {
+                "line": 2,
+                "column": 20
+              }
+            },
+            "atoms": [
+              {
+                "type": "Identifier",
+                "start": 13,
+                "end": 17,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 4
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 8
+                  },
+                  "identifierName": "Atom"
+                },
+                "name": "Atom"
+              }
+            ],
+            "binding": {
+              "type": "ObjectPattern",
+              "start": 23,
+              "end": 26,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 14
+                },
+                "end": {
+                  "line": 2,
+                  "column": 17
+                }
+              },
+              "properties": [
+                {
+                  "type": "ObjectProperty",
+                  "start": 24,
+                  "end": 25,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 15
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 16
+                    }
+                  },
+                  "method": false,
+                  "shorthand": true,
+                  "computed": false,
+                  "key": {
+                    "type": "Identifier",
+                    "start": 24,
+                    "end": 25,
+                    "loc": {
+                      "start": {
+                        "line": 2,
+                        "column": 15
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 16
+                      },
+                      "identifierName": "y"
+                    },
+                    "name": "y"
+                  },
+                  "value": {
+                    "type": "Identifier",
+                    "start": 24,
+                    "end": 25,
+                    "loc": {
+                      "start": {
+                        "line": 2,
+                        "column": 15
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 16
+                      },
+                      "identifierName": "y"
+                    },
+                    "name": "y"
+                  },
+                  "extra": {
+                    "shorthand": true
+                  }
+                }
+              ]
+            },
+            "assertive": true,
+            "consequent": {
+              "type": "ExpressionStatement",
+              "start": 28,
+              "end": 29,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 19
+                },
+                "end": {
+                  "line": 2,
+                  "column": 20
+                }
+              },
+              "expression": {
+                "type": "Identifier",
+                "start": 28,
+                "end": 29,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 19
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 20
+                  },
+                  "identifierName": "y"
+                },
+                "name": "y"
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "directives": []
+  }
+}

--- a/test/fixtures/match/v4/atoms/actual.js
+++ b/test/fixtures/match/v4/atoms/actual.js
@@ -1,0 +1,2 @@
+match x:
+  | Atom, not Atom, Atom and Atom: x

--- a/test/fixtures/match/v4/atoms/expected.json
+++ b/test/fixtures/match/v4/atoms/expected.json
@@ -1,0 +1,221 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 45,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 2,
+      "column": 36
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 45,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 2,
+        "column": 36
+      }
+    },
+    "sourceType": "script",
+    "body": [
+      {
+        "type": "MatchStatement",
+        "start": 0,
+        "end": 45,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 2,
+            "column": 36
+          }
+        },
+        "discriminant": {
+          "type": "Identifier",
+          "start": 6,
+          "end": 7,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 6
+            },
+            "end": {
+              "line": 1,
+              "column": 7
+            },
+            "identifierName": "x"
+          },
+          "name": "x"
+        },
+        "cases": [
+          {
+            "type": "MatchCase",
+            "start": 11,
+            "end": 45,
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 2
+              },
+              "end": {
+                "line": 2,
+                "column": 36
+              }
+            },
+            "atoms": [
+              {
+                "type": "Identifier",
+                "start": 13,
+                "end": 17,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 4
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 8
+                  },
+                  "identifierName": "Atom"
+                },
+                "name": "Atom"
+              },
+              {
+                "type": "UnaryExpression",
+                "start": 19,
+                "end": 27,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 10
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 18
+                  }
+                },
+                "operator": "!",
+                "prefix": true,
+                "argument": {
+                  "type": "Identifier",
+                  "start": 23,
+                  "end": 27,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 14
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 18
+                    },
+                    "identifierName": "Atom"
+                  },
+                  "name": "Atom"
+                },
+                "extra": {
+                  "parenthesizedArgument": false
+                }
+              },
+              {
+                "type": "LogicalExpression",
+                "start": 29,
+                "end": 42,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 20
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 33
+                  }
+                },
+                "left": {
+                  "type": "Identifier",
+                  "start": 29,
+                  "end": 33,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 20
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 24
+                    },
+                    "identifierName": "Atom"
+                  },
+                  "name": "Atom"
+                },
+                "operator": "&&",
+                "right": {
+                  "type": "Identifier",
+                  "start": 38,
+                  "end": 42,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 29
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 33
+                    },
+                    "identifierName": "Atom"
+                  },
+                  "name": "Atom"
+                }
+              }
+            ],
+            "consequent": {
+              "type": "ExpressionStatement",
+              "start": 44,
+              "end": 45,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 35
+                },
+                "end": {
+                  "line": 2,
+                  "column": 36
+                }
+              },
+              "expression": {
+                "type": "Identifier",
+                "start": 44,
+                "end": 45,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 35
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 36
+                  },
+                  "identifierName": "x"
+                },
+                "name": "x"
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "directives": []
+  }
+}

--- a/test/fixtures/match/v4/full-syntax/actual.js
+++ b/test/fixtures/match/v4/full-syntax/actual.js
@@ -1,0 +1,2 @@
+match x:
+  | if preFlag: ~isWidget() and ~isCheap(), not ~isShirt() with { price } if price > 2.0: "yup"

--- a/test/fixtures/match/v4/full-syntax/expected.json
+++ b/test/fixtures/match/v4/full-syntax/expected.json
@@ -1,0 +1,443 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 104,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 2,
+      "column": 95
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 104,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 2,
+        "column": 95
+      }
+    },
+    "sourceType": "script",
+    "body": [
+      {
+        "type": "MatchStatement",
+        "start": 0,
+        "end": 104,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 2,
+            "column": 95
+          }
+        },
+        "discriminant": {
+          "type": "Identifier",
+          "start": 6,
+          "end": 7,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 6
+            },
+            "end": {
+              "line": 1,
+              "column": 7
+            },
+            "identifierName": "x"
+          },
+          "name": "x"
+        },
+        "cases": [
+          {
+            "type": "MatchCase",
+            "start": 11,
+            "end": 104,
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 2
+              },
+              "end": {
+                "line": 2,
+                "column": 95
+              }
+            },
+            "outerGuard": {
+              "type": "Identifier",
+              "start": 16,
+              "end": 23,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 7
+                },
+                "end": {
+                  "line": 2,
+                  "column": 14
+                },
+                "identifierName": "preFlag"
+              },
+              "name": "preFlag"
+            },
+            "atoms": [
+              {
+                "type": "LogicalExpression",
+                "start": 25,
+                "end": 51,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 16
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 42
+                  }
+                },
+                "left": {
+                  "type": "TildeCallExpression",
+                  "start": 25,
+                  "end": 36,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 16
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 27
+                    }
+                  },
+                  "left": {
+                    "type": "MatchPlaceholderExpression",
+                    "start": 24,
+                    "end": 25,
+                    "loc": {
+                      "start": {
+                        "line": 2,
+                        "column": 15
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 16
+                      }
+                    }
+                  },
+                  "right": {
+                    "type": "Identifier",
+                    "start": 26,
+                    "end": 34,
+                    "loc": {
+                      "start": {
+                        "line": 2,
+                        "column": 17
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 25
+                      },
+                      "identifierName": "isWidget"
+                    },
+                    "name": "isWidget"
+                  },
+                  "arguments": []
+                },
+                "operator": "&&",
+                "right": {
+                  "type": "TildeCallExpression",
+                  "start": 41,
+                  "end": 51,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 32
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 42
+                    }
+                  },
+                  "left": {
+                    "type": "MatchPlaceholderExpression",
+                    "start": 40,
+                    "end": 41,
+                    "loc": {
+                      "start": {
+                        "line": 2,
+                        "column": 31
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 32
+                      }
+                    }
+                  },
+                  "right": {
+                    "type": "Identifier",
+                    "start": 42,
+                    "end": 49,
+                    "loc": {
+                      "start": {
+                        "line": 2,
+                        "column": 33
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 40
+                      },
+                      "identifierName": "isCheap"
+                    },
+                    "name": "isCheap"
+                  },
+                  "arguments": []
+                }
+              },
+              {
+                "type": "UnaryExpression",
+                "start": 53,
+                "end": 67,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 44
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 58
+                  }
+                },
+                "operator": "!",
+                "prefix": true,
+                "argument": {
+                  "type": "TildeCallExpression",
+                  "start": 57,
+                  "end": 67,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 48
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 58
+                    }
+                  },
+                  "left": {
+                    "type": "MatchPlaceholderExpression",
+                    "start": 56,
+                    "end": 57,
+                    "loc": {
+                      "start": {
+                        "line": 2,
+                        "column": 47
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 48
+                      }
+                    }
+                  },
+                  "right": {
+                    "type": "Identifier",
+                    "start": 58,
+                    "end": 65,
+                    "loc": {
+                      "start": {
+                        "line": 2,
+                        "column": 49
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 56
+                      },
+                      "identifierName": "isShirt"
+                    },
+                    "name": "isShirt"
+                  },
+                  "arguments": []
+                },
+                "extra": {
+                  "parenthesizedArgument": false
+                }
+              }
+            ],
+            "binding": {
+              "type": "ObjectPattern",
+              "start": 73,
+              "end": 82,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 64
+                },
+                "end": {
+                  "line": 2,
+                  "column": 73
+                }
+              },
+              "properties": [
+                {
+                  "type": "ObjectProperty",
+                  "start": 75,
+                  "end": 80,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 66
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 71
+                    }
+                  },
+                  "method": false,
+                  "shorthand": true,
+                  "computed": false,
+                  "key": {
+                    "type": "Identifier",
+                    "start": 75,
+                    "end": 80,
+                    "loc": {
+                      "start": {
+                        "line": 2,
+                        "column": 66
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 71
+                      },
+                      "identifierName": "price"
+                    },
+                    "name": "price"
+                  },
+                  "value": {
+                    "type": "Identifier",
+                    "start": 75,
+                    "end": 80,
+                    "loc": {
+                      "start": {
+                        "line": 2,
+                        "column": 66
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 71
+                      },
+                      "identifierName": "price"
+                    },
+                    "name": "price"
+                  },
+                  "extra": {
+                    "shorthand": true
+                  }
+                }
+              ]
+            },
+            "assertive": true,
+            "innerGuard": {
+              "type": "BinaryExpression",
+              "start": 86,
+              "end": 97,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 77
+                },
+                "end": {
+                  "line": 2,
+                  "column": 88
+                }
+              },
+              "left": {
+                "type": "Identifier",
+                "start": 86,
+                "end": 91,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 77
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 82
+                  },
+                  "identifierName": "price"
+                },
+                "name": "price"
+              },
+              "operator": ">",
+              "right": {
+                "type": "NumericLiteral",
+                "start": 94,
+                "end": 97,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 85
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 88
+                  }
+                },
+                "extra": {
+                  "rawValue": 2,
+                  "raw": "2.0"
+                },
+                "value": 2
+              }
+            },
+            "consequent": {
+              "type": "ExpressionStatement",
+              "start": 99,
+              "end": 104,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 90
+                },
+                "end": {
+                  "line": 2,
+                  "column": 95
+                }
+              },
+              "expression": {
+                "type": "StringLiteral",
+                "start": 99,
+                "end": 104,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 90
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 95
+                  }
+                },
+                "extra": {
+                  "rawValue": "yup",
+                  "raw": "\"yup\""
+                },
+                "value": "yup"
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "directives": []
+  }
+}

--- a/test/fixtures/match/v4/not-predicate/actual.js
+++ b/test/fixtures/match/v4/not-predicate/actual.js
@@ -1,0 +1,2 @@
+match x:
+  | not ~predicate(): 1

--- a/test/fixtures/match/v4/not-predicate/expected.json
+++ b/test/fixtures/match/v4/not-predicate/expected.json
@@ -1,7 +1,7 @@
 {
   "type": "File",
   "start": 0,
-  "end": 28,
+  "end": 32,
   "loc": {
     "start": {
       "line": 1,
@@ -9,13 +9,13 @@
     },
     "end": {
       "line": 2,
-      "column": 19
+      "column": 23
     }
   },
   "program": {
     "type": "Program",
     "start": 0,
-    "end": 28,
+    "end": 32,
     "loc": {
       "start": {
         "line": 1,
@@ -23,7 +23,7 @@
       },
       "end": {
         "line": 2,
-        "column": 19
+        "column": 23
       }
     },
     "sourceType": "script",
@@ -31,7 +31,7 @@
       {
         "type": "MatchStatement",
         "start": 0,
-        "end": 28,
+        "end": 32,
         "loc": {
           "start": {
             "line": 1,
@@ -39,7 +39,7 @@
           },
           "end": {
             "line": 2,
-            "column": 19
+            "column": 23
           }
         },
         "discriminant": {
@@ -63,7 +63,7 @@
           {
             "type": "MatchCase",
             "start": 11,
-            "end": 28,
+            "end": 32,
             "loc": {
               "start": {
                 "line": 2,
@@ -71,14 +71,14 @@
               },
               "end": {
                 "line": 2,
-                "column": 19
+                "column": 23
               }
             },
             "atoms": [
               {
-                "type": "TildeCallExpression",
+                "type": "UnaryExpression",
                 "start": 13,
-                "end": 25,
+                "end": 29,
                 "loc": {
                   "start": {
                     "line": 2,
@@ -86,70 +86,90 @@
                   },
                   "end": {
                     "line": 2,
-                    "column": 16
+                    "column": 20
                   }
                 },
-                "left": {
-                  "type": "MatchPlaceholderExpression",
-                  "start": 12,
-                  "end": 13,
+                "operator": "!",
+                "prefix": true,
+                "argument": {
+                  "type": "TildeCallExpression",
+                  "start": 17,
+                  "end": 29,
                   "loc": {
                     "start": {
                       "line": 2,
-                      "column": 3
+                      "column": 8
                     },
                     "end": {
                       "line": 2,
-                      "column": 4
+                      "column": 20
                     }
-                  }
-                },
-                "right": {
-                  "type": "Identifier",
-                  "start": 14,
-                  "end": 23,
-                  "loc": {
-                    "start": {
-                      "line": 2,
-                      "column": 5
-                    },
-                    "end": {
-                      "line": 2,
-                      "column": 14
-                    },
-                    "identifierName": "predicate"
                   },
-                  "name": "predicate"
+                  "left": {
+                    "type": "MatchPlaceholderExpression",
+                    "start": 16,
+                    "end": 17,
+                    "loc": {
+                      "start": {
+                        "line": 2,
+                        "column": 7
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 8
+                      }
+                    }
+                  },
+                  "right": {
+                    "type": "Identifier",
+                    "start": 18,
+                    "end": 27,
+                    "loc": {
+                      "start": {
+                        "line": 2,
+                        "column": 9
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 18
+                      },
+                      "identifierName": "predicate"
+                    },
+                    "name": "predicate"
+                  },
+                  "arguments": []
                 },
-                "arguments": []
+                "extra": {
+                  "parenthesizedArgument": false
+                }
               }
             ],
             "consequent": {
               "type": "ExpressionStatement",
-              "start": 27,
-              "end": 28,
+              "start": 31,
+              "end": 32,
               "loc": {
                 "start": {
                   "line": 2,
-                  "column": 18
+                  "column": 22
                 },
                 "end": {
                   "line": 2,
-                  "column": 19
+                  "column": 23
                 }
               },
               "expression": {
                 "type": "NumericLiteral",
-                "start": 27,
-                "end": 28,
+                "start": 31,
+                "end": 32,
                 "loc": {
                   "start": {
                     "line": 2,
-                    "column": 18
+                    "column": 22
                   },
                   "end": {
                     "line": 2,
-                    "column": 19
+                    "column": 23
                   }
                 },
                 "extra": {

--- a/test/fixtures/match/v4/options.json
+++ b/test/fixtures/match/v4/options.json
@@ -1,0 +1,9 @@
+{
+  "alternatives": {
+    "default": {
+      "allPlugins": true,
+      "excludePlugins": ["match_v3"],
+      "includePlugins": ["match_v4"]
+    }
+  }
+}

--- a/test/fixtures/match/v4/predicate-with/actual.js
+++ b/test/fixtures/match/v4/predicate-with/actual.js
@@ -1,0 +1,2 @@
+match x:
+  | ~p() with {y}: y

--- a/test/fixtures/match/v4/predicate-with/expected.json
+++ b/test/fixtures/match/v4/predicate-with/expected.json
@@ -1,0 +1,238 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 29,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 2,
+      "column": 20
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 29,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 2,
+        "column": 20
+      }
+    },
+    "sourceType": "script",
+    "body": [
+      {
+        "type": "MatchStatement",
+        "start": 0,
+        "end": 29,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 2,
+            "column": 20
+          }
+        },
+        "discriminant": {
+          "type": "Identifier",
+          "start": 6,
+          "end": 7,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 6
+            },
+            "end": {
+              "line": 1,
+              "column": 7
+            },
+            "identifierName": "x"
+          },
+          "name": "x"
+        },
+        "cases": [
+          {
+            "type": "MatchCase",
+            "start": 11,
+            "end": 29,
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 2
+              },
+              "end": {
+                "line": 2,
+                "column": 20
+              }
+            },
+            "atoms": [
+              {
+                "type": "TildeCallExpression",
+                "start": 13,
+                "end": 17,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 4
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 8
+                  }
+                },
+                "left": {
+                  "type": "MatchPlaceholderExpression",
+                  "start": 12,
+                  "end": 13,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 3
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 4
+                    }
+                  }
+                },
+                "right": {
+                  "type": "Identifier",
+                  "start": 14,
+                  "end": 15,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 5
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 6
+                    },
+                    "identifierName": "p"
+                  },
+                  "name": "p"
+                },
+                "arguments": []
+              }
+            ],
+            "binding": {
+              "type": "ObjectPattern",
+              "start": 23,
+              "end": 26,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 14
+                },
+                "end": {
+                  "line": 2,
+                  "column": 17
+                }
+              },
+              "properties": [
+                {
+                  "type": "ObjectProperty",
+                  "start": 24,
+                  "end": 25,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 15
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 16
+                    }
+                  },
+                  "method": false,
+                  "shorthand": true,
+                  "computed": false,
+                  "key": {
+                    "type": "Identifier",
+                    "start": 24,
+                    "end": 25,
+                    "loc": {
+                      "start": {
+                        "line": 2,
+                        "column": 15
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 16
+                      },
+                      "identifierName": "y"
+                    },
+                    "name": "y"
+                  },
+                  "value": {
+                    "type": "Identifier",
+                    "start": 24,
+                    "end": 25,
+                    "loc": {
+                      "start": {
+                        "line": 2,
+                        "column": 15
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 16
+                      },
+                      "identifierName": "y"
+                    },
+                    "name": "y"
+                  },
+                  "extra": {
+                    "shorthand": true
+                  }
+                }
+              ]
+            },
+            "assertive": true,
+            "consequent": {
+              "type": "ExpressionStatement",
+              "start": 28,
+              "end": 29,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 19
+                },
+                "end": {
+                  "line": 2,
+                  "column": 20
+                }
+              },
+              "expression": {
+                "type": "Identifier",
+                "start": 28,
+                "end": 29,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 19
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 20
+                  },
+                  "identifierName": "y"
+                },
+                "name": "y"
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "directives": []
+  }
+}

--- a/test/fixtures/match/v4/predicate/actual.js
+++ b/test/fixtures/match/v4/predicate/actual.js
@@ -1,0 +1,2 @@
+match x:
+  | ~predicate(): 1

--- a/test/fixtures/match/v4/predicate/expected.json
+++ b/test/fixtures/match/v4/predicate/expected.json
@@ -1,0 +1,168 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 28,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 2,
+      "column": 19
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 28,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 2,
+        "column": 19
+      }
+    },
+    "sourceType": "script",
+    "body": [
+      {
+        "type": "MatchStatement",
+        "start": 0,
+        "end": 28,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 2,
+            "column": 19
+          }
+        },
+        "discriminant": {
+          "type": "Identifier",
+          "start": 6,
+          "end": 7,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 6
+            },
+            "end": {
+              "line": 1,
+              "column": 7
+            },
+            "identifierName": "x"
+          },
+          "name": "x"
+        },
+        "cases": [
+          {
+            "type": "MatchCase",
+            "start": 11,
+            "end": 28,
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 2
+              },
+              "end": {
+                "line": 2,
+                "column": 19
+              }
+            },
+            "atoms": [
+              {
+                "type": "TildeCallExpression",
+                "start": 13,
+                "end": 25,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 4
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 16
+                  }
+                },
+                "left": {
+                  "type": "PlaceholderExpression",
+                  "start": 12,
+                  "end": 13,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 3
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 4
+                    }
+                  }
+                },
+                "right": {
+                  "type": "Identifier",
+                  "start": 14,
+                  "end": 23,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 5
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 14
+                    },
+                    "identifierName": "predicate"
+                  },
+                  "name": "predicate"
+                },
+                "arguments": []
+              }
+            ],
+            "consequent": {
+              "type": "ExpressionStatement",
+              "start": 27,
+              "end": 28,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 18
+                },
+                "end": {
+                  "line": 2,
+                  "column": 19
+                }
+              },
+              "expression": {
+                "type": "NumericLiteral",
+                "start": 27,
+                "end": 28,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 18
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 19
+                  }
+                },
+                "extra": {
+                  "rawValue": 1,
+                  "raw": "1"
+                },
+                "value": 1
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "directives": []
+  }
+}


### PR DESCRIPTION
```js
// v4 of the match syntax
// MatchStatement = `match` Expr `:` `\n`MatchCase [`\n`MatchCase]...
// MatchCase = `|` ` ` MatchTest | MatchElse
// MatchTest = [`if` Expr:] [MatchAtom, MatchAtom, ...] [`with`|`as` MatchBinding] [`if` Expr]: Block
// MatchElse = | `else` [`as` MatchBinding]: Block
// MatchBinding = ArrayPattern|ObjectPattern
// MatchAtom = ExprOps
```